### PR TITLE
GH-77 - Use generic T instead of Fqn for interface methods

### DIFF
--- a/src/main/java/com/ntu/fyp/sdn6/dao/FqnBaseRepository.java
+++ b/src/main/java/com/ntu/fyp/sdn6/dao/FqnBaseRepository.java
@@ -12,10 +12,10 @@ public interface FqnBaseRepository<T extends Fqn> extends Repository<T, Long> {
 
   T findByName(@Param("name") String name);
 
-  List<Fqn> findByContainedFqnsContainedFqnName(@Param("name") String name);
+  List<T> findByContainedFqnsContainedFqnName(@Param("name") String name);
 
-  List<Fqn> findByReferencedFqnsReferencedFqnName(@Param("name") String name);
+  List<T> findByReferencedFqnsReferencedFqnName(@Param("name") String name);
 
-  List<Fqn> findByInsertedFqnsInsertedFqnName(@Param("name") String name);
+  List<T> findByInsertedFqnsInsertedFqnName(@Param("name") String name);
 
 }


### PR DESCRIPTION
Closes #77.