### PR TITLE
GH-96 - Update gitignore to handle certain Neo4j subdirectories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,13 @@ build/
 
 ### VS Code ###
 .vscode/
+
+# General
+.DS_Store
+
+# Neo4j
+neo4j/data/
+neo4j/logs/
+neo4j/import/datalog/
+neo4j/plugins/
+


### PR DESCRIPTION
Closes #96.